### PR TITLE
Fix: mobile padding variable undefined #1008

### DIFF
--- a/src/styles/layout.scss
+++ b/src/styles/layout.scss
@@ -487,12 +487,12 @@ details {
     }
 
     > a {
-      padding: var(--space-10);
+      padding: var(--space-08);
     }
   }
 
   .dark-mode-toggle {
-    padding: var(--space-10);
+    padding: var(--space-08);
   }
 
   .right-container .nav__tabs > a:last-child {


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.dev/blob/master/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/master/CONTRIBUTING.md) before opening a pull request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
@media (max-width: 800px)
.nav__tabs > a 
Currently using "--space-10" for padding which is undefined. Changed to "--space-08"

## Related Issues
Fixes #1008 Increase the spacing for main navigation links on mobile
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

<!--
  If you want to generate a preview of this PR on our staging server please
  make a comment on the Pull-Request with the text `/preview`
 -->